### PR TITLE
feat: Update detector to publish arrays of objects and load ball colo…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,14 @@ find_package(image_transport REQUIRED)
 find_package(cv_bridge REQUIRED)
 find_package(OpenCV REQUIRED)
 
+rosidl_generate_interfaces(${PROJECT_NAME}
+  "msg/BallPosition.msg"
+  "msg/LineSegment.msg"
+  "msg/BallPositionArray.msg"
+  "msg/LineSegmentArray.msg"
+  DEPENDENCIES geometry_msgs std_msgs builtin_interfaces
+)
+
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   # the following line skips the linter which checks for copyrights

--- a/include/image_detector/detector_node.hpp
+++ b/include/image_detector/detector_node.hpp
@@ -8,6 +8,8 @@
 #include <opencv2/opencv.hpp>
 #include "image_detector/msg/line_segment.hpp"
 #include "image_detector/msg/ball_position.hpp"
+#include "image_detector/msg/ball_position_array.hpp"
+#include "image_detector/msg/line_segment_array.hpp"
 
 struct LineParams {
   double rho;

--- a/msg/BallPositionArray.msg
+++ b/msg/BallPositionArray.msg
@@ -1,0 +1,1 @@
+image_detector/BallPosition[] balls

--- a/msg/LineSegmentArray.msg
+++ b/msg/LineSegmentArray.msg
@@ -1,0 +1,1 @@
+image_detector/LineSegment[] lines

--- a/package.xml
+++ b/package.xml
@@ -16,6 +16,9 @@
   <depend>cv_bridge</depend>
   <depend>OpenCV</depend>
   <depend>message_generation</depend>
+  <build_depend>rosidl_default_generators</build_depend>
+  <exec_depend>rosidl_default_runtime</exec_depend>
+  <member_of_group>rosidl_interface_packages</member_of_group>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/src/detenctor_node.cpp
+++ b/src/detenctor_node.cpp
@@ -1,4 +1,4 @@
-#include "image_detector/src/detector_node.hpp"
+#include "image_detector/detector_node.hpp"
 
 DetectorNode::DetectorNode()
 : Node("image_detector")
@@ -27,14 +27,65 @@ DetectorNode::DetectorNode()
   this->get_parameter("detection.line.min_line_length", line_params_.min_line_length);
   this->get_parameter("detection.line.max_line_gap", line_params_.max_line_gap);
 
+  for (int i = 0; i < 5; ++i) { // Assuming max 5 ball configurations for direct declaration
+      std::string ball_prefix = "detection.balls." + std::to_string(i) + ".";
+      this->declare_parameter<std::string>(ball_prefix + "name", "");
+      this->declare_parameter<std::vector<long int>>(ball_prefix + "hsv_lower", std::vector<long int>{0,0,0});
+      this->declare_parameter<std::vector<long int>>(ball_prefix + "hsv_upper", std::vector<long int>{0,0,0});
+  }
+
   // 色指定（YAML 上では配列構造なので、ここは後で適宜拡張してください）
   // 例として赤と青を固定で設定
-  ball_colors_.push_back({"red",   cv::Scalar(0,120,70),   cv::Scalar(10,255,255)});
-  ball_colors_.push_back({"blue",  cv::Scalar(100,150,0), cv::Scalar(140,255,255)});
+  // ball_colors_.push_back({"red",   cv::Scalar(0,120,70),   cv::Scalar(10,255,255)});
+  // ball_colors_.push_back({"blue",  cv::Scalar(100,150,0), cv::Scalar(140,255,255)});
+
+  RCLCPP_INFO(this->get_logger(), "Loading ball color configurations from parameters...");
+  ball_colors_.clear(); // Ensure it's empty before loading
+
+  for (int i = 0; i < 5; ++i) { // Corresponds to the 0-4 declarations
+      std::string ball_prefix = "detection.balls." + std::to_string(i) + ".";
+      std::string name_param_key = ball_prefix + "name";
+      std::string hsv_lower_param_key = ball_prefix + "hsv_lower";
+      std::string hsv_upper_param_key = ball_prefix + "hsv_upper";
+
+      std::string ball_name;
+      this->get_parameter(name_param_key, ball_name);
+
+      if (!ball_name.empty()) {
+          std::vector<long int> hsv_lower_values;
+          std::vector<long int> hsv_upper_values;
+          // It's good practice to check if the parameter exists before getting, though get_parameter can use the default.
+          // For our declared params, they will exist.
+          this->get_parameter(hsv_lower_param_key, hsv_lower_values);
+          this->get_parameter(hsv_upper_param_key, hsv_upper_values);
+
+          if (hsv_lower_values.size() == 3 && hsv_upper_values.size() == 3) {
+              BallColor bc;
+              bc.name = ball_name;
+              bc.hsv_lower = cv::Scalar(static_cast<int>(hsv_lower_values[0]), static_cast<int>(hsv_lower_values[1]), static_cast<int>(hsv_lower_values[2]));
+              bc.hsv_upper = cv::Scalar(static_cast<int>(hsv_upper_values[0]), static_cast<int>(hsv_upper_values[1]), static_cast<int>(hsv_upper_values[2]));
+              ball_colors_.push_back(bc);
+              RCLCPP_INFO(this->get_logger(), "Loaded ball color: %s, HSV Lower: [%ld, %ld, %ld], HSV Upper: [%ld, %ld, %ld]",
+                          bc.name.c_str(),
+                          hsv_lower_values[0], hsv_lower_values[1], hsv_lower_values[2],
+                          hsv_upper_values[0], hsv_upper_values[1], hsv_upper_values[2]);
+          } else {
+              RCLCPP_WARN(this->get_logger(), "Invalid HSV array sizes for ball '%s' (index %d). Expected 3 values each for lower and upper. Lower size: %zu, Upper size: %zu", ball_name.c_str(), i, hsv_lower_values.size(), hsv_upper_values.size());
+          }
+      } else {
+          // This means no name was provided for detection.balls.i.name, so we assume it's the end of the list in YAML.
+          // Or, if we want to be strict about 0 to N-1 being filled, this loop structure is fine.
+          // If names are sparsely populated (e.g. 0 and 2 but not 1), this also works.
+      }
+  }
+
+  if (ball_colors_.empty()) {
+      RCLCPP_WARN(this->get_logger(), "No ball colors loaded from parameters. Ball detection will not detect any specific colors based on YAML configuration.");
+  }
 
   // Publisher
-  line_pub_ = this->create_publisher<image_detector::msg::LineSegment>(line_topic_, queue_size_);
-  ball_pub_ = this->create_publisher<image_detector::msg::BallPosition>(ball_topic_, queue_size_);
+  line_pub_ = this->create_publisher<image_detector::msg::LineSegmentArray>(line_topic_, queue_size_);
+  ball_pub_ = this->create_publisher<image_detector::msg::BallPositionArray>(ball_topic_, queue_size_);
 
   // Subscriber
   image_transport::ImageTransport it(this->shared_from_this());
@@ -67,18 +118,21 @@ void DetectorNode::imageCallback(const sensor_msgs::msg::Image::ConstSharedPtr &
   );
 
   // 検出直線を publish
+  auto msg_line_array = image_detector::msg::LineSegmentArray();
   for (auto & l : lines) {
-    auto msg_line = image_detector::msg::LineSegment();
-    msg_line.start.x = l[0];
-    msg_line.start.y = l[1];
-    msg_line.end.x   = l[2];
-    msg_line.end.y   = l[3];
-    line_pub_->publish(msg_line);
+    image_detector::msg::LineSegment line_segment;
+    line_segment.start.x = l[0];
+    line_segment.start.y = l[1];
+    line_segment.end.x   = l[2];
+    line_segment.end.y   = l[3];
+    msg_line_array.lines.push_back(line_segment);
   }
+  line_pub_->publish(msg_line_array);
 
   // ボール検出（HSV で inRange → 輪郭抽出 → 重心算出）
   cv::Mat hsv;
   cv::cvtColor(bgr, hsv, cv::COLOR_BGR2HSV);
+  auto msg_ball_array = image_detector::msg::BallPositionArray();
   for (auto & bc : ball_colors_) {
     cv::Mat mask;
     cv::inRange(hsv, bc.hsv_lower, bc.hsv_upper, mask);
@@ -91,10 +145,11 @@ void DetectorNode::imageCallback(const sensor_msgs::msg::Image::ConstSharedPtr &
         bp.color = bc.name;
         bp.position.x = m.m10 / m.m00;
         bp.position.y = m.m01 / m.m00;
-        ball_pub_->publish(bp);
+        msg_ball_array.balls.push_back(bp);
       }
     }
   }
+  ball_pub_->publish(msg_ball_array);
 }
 
 int main(int argc, char ** argv)


### PR DESCRIPTION
…rs from YAML

This commit implements the following changes:

1.  **Modified Message Definitions:**
    - Introduced `BallPositionArray.msg` and `LineSegmentArray.msg` to publish lists of detected balls and lines, respectively. This replaces the previous behavior of publishing one message per detected object.

2.  **Updated Node Implementation (`DetectorNode`):**
    - Changed publishers to use the new array message types.
    - Modified `imageCallback` to aggregate all detected balls and lines within a single image frame and publish them as single array messages.
    - Implemented loading of ball color configurations (name, HSV lower/upper bounds) from parameters, which are expected to be set via `config/config.yaml`. This replaces hardcoded ball colors and allows you to define custom colors, including "black" for object detection if needed.
    - Parameter loading for ball colors expects a structure like `detection.balls.0.name`, `detection.balls.0.hsv_lower`, etc. in the YAML file.

3.  **Updated Build Files:**
    - Added new message definitions to `CMakeLists.txt`.
    - Ensured necessary dependencies in `package.xml`.

**Note:** Due to limitations in the development environment (lack of ROS 2 Humble and colcon build tools), I could not compile or test these changes. Thorough building and testing in a ROS 2 Humble environment are required before deployment.