### PR TITLE
Update detection to handle HSV input

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -86,7 +86,7 @@ ros2 run image_detector detector_node --ros-args --params-file src/image_detecto
 
 ### Subscribe
 - **入力画像**: `/camera/resize_hsv/image_raw` (sensor_msgs/Image)
-  - BGR8フォーマットの画像を受信
+  - HSVフォーマットの画像を受信
 
 ### Publish
 - **検出された直線**: `/detection/lines` (image_detector/LineSegmentArray)

--- a/src/detector_node.cpp
+++ b/src/detector_node.cpp
@@ -119,12 +119,19 @@ void DetectorNode::imageCallback(const sensor_msgs::msg::Image::ConstSharedPtr &
 {
   try {
     // OpenCV Mat に変換
-    cv_bridge::CvImagePtr cv_ptr = cv_bridge::toCvCopy(msg, sensor_msgs::image_encodings::BGR8);
-    cv::Mat bgr = cv_ptr->image;
-    
-    // 黒い太い線のみを検出するための処理
+    cv_bridge::CvImagePtr cv_ptr = cv_bridge::toCvCopy(msg, msg->encoding);
     cv::Mat hsv;
-    cv::cvtColor(bgr, hsv, cv::COLOR_BGR2HSV);
+
+    if (msg->encoding == sensor_msgs::image_encodings::BGR8) {
+      cv::cvtColor(cv_ptr->image, hsv, cv::COLOR_BGR2HSV);
+    } else if (msg->encoding == sensor_msgs::image_encodings::RGB8) {
+      cv::cvtColor(cv_ptr->image, hsv, cv::COLOR_RGB2HSV);
+    } else {
+      // 入力がすでにHSVと仮定
+      hsv = cv_ptr->image;
+    }
+
+    // 黒い太い線のみを検出するための処理
     
     // 黒色の範囲（HSVで黒は低いV値）
     cv::Mat black_mask;


### PR DESCRIPTION
## Summary
- adjust subscriber instructions in README to indicate HSV images are expected
- update detector node to skip HSV conversion if incoming image is already HSV

## Testing
- `colcon test --packages-select image_detector` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a550adf108323b815da8807c23afc