### PR TITLE
Add morphological open and tunable kernel

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -11,6 +11,7 @@ ROS 2パッケージで、カメラ画像から直線とカラーボールを検
 ## 機能
 
 ### 直線検出
+- 適応閾値後に形態学的な開閉処理を行いノイズを除去
 - Cannyエッジ検出とHoughLinesP変換を使用
 - 検出された直線の始点と終点の座標を出力
 
@@ -64,6 +65,7 @@ detection:
     max_line_gap: 10      # 直線の最大ギャップ
     adaptive_block_size: 15  # 黒線検出用の適応閾値サイズ
     adaptive_C: 5.0          # 適応閾値計算時の補正値
+    morph_kernel_size: 5     # 開閉処理に使うカーネルサイズ
 
   balls:
     - name: "red"         # 赤いボール
@@ -129,6 +131,7 @@ image_detector/BallPosition[] balls  # ボールの配列
 - `max_line_gap`: 途切れた直線をつなげたい場合は値を上げる
 - `adaptive_block_size`: 画像の照明変化に強い黒線検出のための局所領域サイズ
 - `adaptive_C`: 適応閾値計算時に引かれるオフセット値
+- `morph_kernel_size`: 黒線マスクに対する開閉処理で使用するカーネルのサイズ
 
 ### ボール検出の改善
 - HSV範囲の調整：

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -12,6 +12,7 @@ image_detector:
         max_line_gap: 50.0
         adaptive_block_size: 15
         adaptive_C: 5.0
+        morph_kernel_size: 5
 
     # ballsをdetectionの外に移動し、フラットな構造にする
     detection.balls.0.name: "red"

--- a/include/image_detector/detector_node.hpp
+++ b/include/image_detector/detector_node.hpp
@@ -19,6 +19,8 @@ struct LineParams {
   // parameters for adaptive thresholding when detecting black lines
   int adaptive_block_size;
   double adaptive_C;
+  // kernel size used for morphological operations on the black line mask
+  int morph_kernel_size;
 };
 
 struct BallColor {


### PR DESCRIPTION
## Summary
- add morph kernel size parameter for black line processing
- run morphological OPEN step prior to closing/dilate
- document new kernel parameter

## Testing
- `cmake -S . -B build` *(fails: Could not find ament_cmake)*

------
https://chatgpt.com/codex/tasks/task_e_684b2aff99488323ac73a5eebbf84fce